### PR TITLE
Show more decimals in vault reports for high value crypto

### DIFF
--- a/src/static/js/ethers_helper.js
+++ b/src/static/js/ethers_helper.js
@@ -93,6 +93,26 @@ const toFixed = function(num, fixed) {
   }
 }
 
+const decimalsForSmallNumber = function(num) {
+  if (!num) {
+      return 2
+  }
+
+  if (num < 0.000001) {
+      return 8
+  }
+
+  if (num < 0.0001) {
+      return 6
+  }
+
+  if (num < 0.01) {
+      return 4
+  }
+
+  return 2
+}
+
 const start = function(f) {
   f().catch(e => {
     _print(e)

--- a/src/static/js/yvault.js
+++ b/src/static/js/yvault.js
@@ -242,30 +242,9 @@ const printVault = async function(vault, App) {
     _print(`                  = ${toDollar(yourVaultTokenInUnderlyingTokenAmount * vault.tokenPrice)}\n`);
 
     if (yourVaultTokenAmount * vault.tokenPrice > 1) {
-        let histDailyDecimals = 2;
-        if (yourDailyGains !== 0) {
-            if (yourDailyGains < 0.000001) {
-                histDailyDecimals = 8;
-            } else if (yourDailyGains < 0.0001) {
-                histDailyDecimals = 6;
-            } else if (yourDailyGains < 0.01) {
-                histDailyDecimals = 4;
-            }
-        }
-        _print(`Hist. Daily ROI   : ${toFixed(vault.ROI_day, 4)}% (${toFixed(yourDailyGains, histDailyDecimals)} ${vault.tokenTicker})`);
+        _print(`Hist. Daily ROI   : ${toFixed(vault.ROI_day, 4)}% (${toFixed(yourDailyGains, decimalsForSmallNumber(yourDailyGains))} ${vault.tokenTicker})`);
         _print(`                  = ${toDollar(toFixed(yourDailyGains, 2) * vault.tokenPrice)}\n`);
-
-        let histWeeklyDecimals = 2;
-        if (yourWeeklyGains !== 0) {
-            if (yourWeeklyGains < 0.000001) {
-                histWeeklyDecimals = 8;
-            } else if (yourWeeklyGains < 0.0001) {
-                histWeeklyDecimals = 6;
-            } else if (yourWeeklyGains < 0.01) {
-                histWeeklyDecimals = 4;
-            }
-        }
-        _print(`Hist. Weekly ROI  : ${toFixed(vault.ROI_week, 4)}% (${toFixed(yourWeeklyGains, histWeeklyDecimals)} ${vault.tokenTicker})`);
+        _print(`Hist. Weekly ROI  : ${toFixed(vault.ROI_week, 4)}% (${toFixed(yourWeeklyGains, decimalsForSmallNumber(yourWeeklyGains))} ${vault.tokenTicker})`);
         _print(`                  = ${toDollar(toFixed(yourWeeklyGains, 2) * vault.tokenPrice)}\n`);
     } else {
         _print(`Hist. Daily ROI   : ${toFixed(vault.ROI_day, 4)}%`);

--- a/src/static/js/yvault.js
+++ b/src/static/js/yvault.js
@@ -242,10 +242,13 @@ const printVault = async function(vault, App) {
     _print(`                  = ${toDollar(yourVaultTokenInUnderlyingTokenAmount * vault.tokenPrice)}\n`);
 
     if (yourVaultTokenAmount * vault.tokenPrice > 1) {
-        _print(`Hist. Daily ROI   : ${toFixed(vault.ROI_day, 4)}% (${toFixed(yourDailyGains, decimalsForSmallNumber(yourDailyGains))} ${vault.tokenTicker})`);
-        _print(`                  = ${toDollar(toFixed(yourDailyGains, 2) * vault.tokenPrice)}\n`);
-        _print(`Hist. Weekly ROI  : ${toFixed(vault.ROI_week, 4)}% (${toFixed(yourWeeklyGains, decimalsForSmallNumber(yourWeeklyGains))} ${vault.tokenTicker})`);
-        _print(`                  = ${toDollar(toFixed(yourWeeklyGains, 2) * vault.tokenPrice)}\n`);
+        const histDailyDecimals = decimalsForSmallNumber(yourDailyGains);
+        _print(`Hist. Daily ROI   : ${toFixed(vault.ROI_day, 4)}% (${toFixed(yourDailyGains, histDailyDecimals)} ${vault.tokenTicker})`);
+        _print(`                  = ${toDollar(toFixed(yourDailyGains, histDailyDecimals) * vault.tokenPrice)}\n`);
+
+        const histWeeklyDecimals = decimalsForSmallNumber(yourDailyGains);
+        _print(`Hist. Weekly ROI  : ${toFixed(vault.ROI_week, 4)}% (${toFixed(yourWeeklyGains, histWeeklyDecimals)} ${vault.tokenTicker})`);
+        _print(`                  = ${toDollar(toFixed(yourWeeklyGains, histWeeklyDecimals) * vault.tokenPrice)}\n`);
     } else {
         _print(`Hist. Daily ROI   : ${toFixed(vault.ROI_day, 4)}%`);
         _print(`Hist. Weekly ROI  : ${toFixed(vault.ROI_week, 4)}%\n`);

--- a/src/static/js/yvault.js
+++ b/src/static/js/yvault.js
@@ -242,11 +242,29 @@ const printVault = async function(vault, App) {
     _print(`                  = ${toDollar(yourVaultTokenInUnderlyingTokenAmount * vault.tokenPrice)}\n`);
 
     if (yourVaultTokenAmount * vault.tokenPrice > 1) {
-        const histDailyDecimals = yourDailyGains !== 0 && yourDailyGains < 0.01 ? 4 : 2;
+        let histDailyDecimals = 2;
+        if (yourDailyGains !== 0) {
+            if (yourDailyGains < 0.000001) {
+                histDailyDecimals = 8;
+            } else if (yourDailyGains < 0.0001) {
+                histDailyDecimals = 6;
+            } else if (yourDailyGains < 0.01) {
+                histDailyDecimals = 4;
+            }
+        }
         _print(`Hist. Daily ROI   : ${toFixed(vault.ROI_day, 4)}% (${toFixed(yourDailyGains, histDailyDecimals)} ${vault.tokenTicker})`);
         _print(`                  = ${toDollar(toFixed(yourDailyGains, 2) * vault.tokenPrice)}\n`);
 
-        const histWeeklyDecimals = yourWeeklyGains !== 0 && yourWeeklyGains < 0.01 ? 4 : 2;
+        let histWeeklyDecimals = 2;
+        if (yourWeeklyGains !== 0) {
+            if (yourWeeklyGains < 0.000001) {
+                histWeeklyDecimals = 8;
+            } else if (yourWeeklyGains < 0.0001) {
+                histWeeklyDecimals = 6;
+            } else if (yourWeeklyGains < 0.01) {
+                histWeeklyDecimals = 4;
+            }
+        }
         _print(`Hist. Weekly ROI  : ${toFixed(vault.ROI_week, 4)}% (${toFixed(yourWeeklyGains, histWeeklyDecimals)} ${vault.tokenTicker})`);
         _print(`                  = ${toDollar(toFixed(yourWeeklyGains, 2) * vault.tokenPrice)}\n`);
     } else {

--- a/src/static/js/yvault.js
+++ b/src/static/js/yvault.js
@@ -242,9 +242,12 @@ const printVault = async function(vault, App) {
     _print(`                  = ${toDollar(yourVaultTokenInUnderlyingTokenAmount * vault.tokenPrice)}\n`);
 
     if (yourVaultTokenAmount * vault.tokenPrice > 1) {
-        _print(`Hist. Daily ROI   : ${toFixed(vault.ROI_day, 4)}% (${toFixed(yourDailyGains, 2)} ${vault.tokenTicker})`);
+        const histDailyDecimals = yourDailyGains !== 0 && yourDailyGains < 0.01 ? 4 : 2;
+        _print(`Hist. Daily ROI   : ${toFixed(vault.ROI_day, 4)}% (${toFixed(yourDailyGains, histDailyDecimals)} ${vault.tokenTicker})`);
         _print(`                  = ${toDollar(toFixed(yourDailyGains, 2) * vault.tokenPrice)}\n`);
-        _print(`Hist. Weekly ROI  : ${toFixed(vault.ROI_week, 4)}% (${toFixed(yourWeeklyGains, 2)} ${vault.tokenTicker})`);
+
+        const histWeeklyDecimals = yourWeeklyGains !== 0 && yourWeeklyGains < 0.01 ? 4 : 2;
+        _print(`Hist. Weekly ROI  : ${toFixed(vault.ROI_week, 4)}% (${toFixed(yourWeeklyGains, histWeeklyDecimals)} ${vault.tokenTicker})`);
         _print(`                  = ${toDollar(toFixed(yourWeeklyGains, 2) * vault.tokenPrice)}\n`);
     } else {
         _print(`Hist. Daily ROI   : ${toFixed(vault.ROI_day, 4)}%`);


### PR DESCRIPTION
The problem I am trying to solve is for non whales using vaults to see accurate reporting. E.g.: when you deposit 1 BTC in the `crvRenWSBTC` vault it will report you are making $0.00 per day & week (while in fact, you are making money).
```================== crvRenWSBTC ================== 
1 crvRenWSBTC     = $10177.803283880678
1 ycrvRenWSBTC    = 1.018140 crvRenWSBTC

Current strategy  : 0x4FEeaecED575239b46d70b50E13532ECB62e4ea8

There are total   : 1764.5519702327392 crvRenWSBTC staked in crvRenWSBTC vault
                  = $17,959,262.84

You own           : 0.9867273255696911 ycrvRenWSBTC   

You are staking   : 1.004626922746987 crvRenWSBTC
                  = $10,224.90

Hist. Daily ROI   : 0.1160% (0.00 crvRenWSBTC)
                  = $0.00

Hist. Weekly ROI  : 0.8750% (0.00 crvRenWSBTC)
                  = $0.00

APY (daily)       : 52.7294%
APY (weekly)      : 57.3114%
```

This PR solves this and will, based on value, show more decimals for the crypto value & use this in the dollar calculation.
```================== crvRenWSBTC ================== 
1 crvRenWSBTC     = $10199.626742306593
1 ycrvRenWSBTC    = 1.018140 crvRenWSBTC

Current strategy  : 0x4FEeaecED575239b46d70b50E13532ECB62e4ea8

There are total   : 1765.5725692542362 crvRenWSBTC staked in crvRenWSBTC vault
                  = $18,008,181.19

You own           : 0.9867273255696911 ycrvRenWSBTC   

You are staking   : 1.004626922746987 crvRenWSBTC
                  = $10,246.82

Hist. Daily ROI   : 0.1160% (0.0011 crvRenWSBTC)
                  = $11.22

Hist. Weekly ROI  : 0.8750% (0.0087 crvRenWSBTC)
                  = $88.74

APY (daily)       : 52.7294%
APY (weekly)      : 57.3114%
```